### PR TITLE
Fix compilation and desugar shaku macros to allow generics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,8 +420,7 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 [[package]]
 name = "shaku"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fe96e02be1fc6febbd04092382345d089bebed177635736fcdced1611f6d45"
+source = "git+https://github.com/Mcat12/shaku.git#9c7d394aac66fd5ef0d2b46dec0ff48b6e66254b"
 dependencies = [
  "anymap",
  "shaku_derive",
@@ -440,8 +439,7 @@ dependencies = [
 [[package]]
 name = "shaku_derive"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44846d3b7e53695b77557000c93175f93313b5006a9ee969f1cc549ee6d29c8a"
+source = "git+https://github.com/Mcat12/shaku.git#9c7d394aac66fd5ef0d2b46dec0ff48b6e66254b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7505eeebd78492e0f6108f7171c4948dbb120ee8119d9d77d0afa5469bef67f"
+checksum = "9df32da11d84f3a7d70205549562966279adb900e080fad3dccd8e64afccf0ad"
 
 [[package]]
 name = "pin-utils"
@@ -365,9 +365,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0deb65f46e873ba8aa7c6a8dbe3f23cb1bf59c339a81a1d56361dde4d66ac8"
+checksum = "01608bfa680dafb103f9207fa944facf572e4e3e708d10de19a0d0c3d36e5f18"
 dependencies = [
  "crossbeam-utils",
  "futures-io",
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1502d12e458c49a4c9cbff560d0fe0060c252bc29799ed94ca2ed4bb665a0101"
+checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 dependencies = [
  "unicode-xid",
 ]
@@ -420,7 +420,7 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 [[package]]
 name = "shaku"
 version = "0.4.0"
-source = "git+https://github.com/Mcat12/shaku.git#9c7d394aac66fd5ef0d2b46dec0ff48b6e66254b"
+source = "git+https://github.com/Mcat12/shaku.git#8c72422ff04f1beec579c756be8390f9f48f6cdc"
 dependencies = [
  "anymap",
  "shaku_derive",
@@ -439,7 +439,7 @@ dependencies = [
 [[package]]
 name = "shaku_derive"
 version = "0.4.0"
-source = "git+https://github.com/Mcat12/shaku.git#9c7d394aac66fd5ef0d2b46dec0ff48b6e66254b"
+source = "git+https://github.com/Mcat12/shaku.git#8c72422ff04f1beec579c756be8390f9f48f6cdc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -485,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb37da98a55b1d08529362d9cbb863be17556873df2585904ab9d2bc951291d0"
+checksum = "93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,8 +419,9 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "shaku"
-version = "0.4.0"
-source = "git+https://github.com/Mcat12/shaku.git#8c72422ff04f1beec579c756be8390f9f48f6cdc"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065dc1468565e8b12973240896ab4504923976e2b61530e86f52a9c83fe38c8d"
 dependencies = [
  "anymap",
  "shaku_derive",
@@ -433,13 +434,13 @@ dependencies = [
  "async-std",
  "async-trait",
  "shaku",
- "shaku_derive",
 ]
 
 [[package]]
 name = "shaku_derive"
-version = "0.4.0"
-source = "git+https://github.com/Mcat12/shaku.git#8c72422ff04f1beec579c756be8390f9f48f6cdc"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e298b87f021474ced2baf874b8104b1cfa64a3edb03024cbd05318d42b7f83"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.shaku]
-version = "0.4.0"
+git = "https://github.com/Mcat12/shaku.git"
 
 [dependencies.shaku_derive]
-version = "0.4.0"
+git = "https://github.com/Mcat12/shaku.git"
 
 [dependencies.async-trait]
 version = "0.1.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.shaku]
-git = "https://github.com/Mcat12/shaku.git"
-
-[dependencies.shaku_derive]
-git = "https://github.com/Mcat12/shaku.git"
+version = "0.4.1"
 
 [dependencies.async-trait]
 version = "0.1.31"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,16 @@
-#[macro_use]
-extern crate shaku_derive;
+use async_trait::async_trait;
+use shaku::{Component, HasComponent, Interface, Module, ModuleBuildContext, ModuleBuilder};
+use std::marker::PhantomData;
+use std::sync::Arc;
 
-#[macro_use]
-extern crate async_trait;
+pub trait Executor: Interface + Default {}
 
-#[macro_use]
-extern crate async_std;
-
-use shaku::{module, Component, Interface, HasComponent};
-
-pub trait Executor {}
-
+#[derive(Default)]
 pub struct SqlConnection;
 
 impl Executor for SqlConnection {}
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct DbPool;
 
 impl Executor for DbPool {}
@@ -25,36 +20,82 @@ pub trait MyService: Interface {
     async fn foo(&self) -> u16;
 }
 
-#[derive(Component)]
-#[shaku(interface = MyService)]
+// #[derive(Component)]
+// #[shaku(interface = MyService)]
 pub struct MyServiceImpl<E>
-    where E: Executor,
+where
+    E: Executor,
 {
+    #[allow(dead_code)]
     executor: E,
 }
 
+impl<E: Executor, M: Module> Component<M> for MyServiceImpl<E> {
+    type Interface = dyn MyService;
+    type Parameters = E;
+
+    fn build(_context: &mut ModuleBuildContext<M>, params: E) -> Box<dyn MyService> {
+        Box::new(Self { executor: params })
+    }
+}
+
+#[async_trait]
 impl<E> MyService for MyServiceImpl<E>
-    where E: Executor,
+where
+    E: Executor,
 {
     async fn foo(&self) -> u16 {
         1337
     }
 }
 
-module! {
-    MyModule {
-        components = [MyServiceImpl],
-        providers = []
+// module! {
+//     MyModule {
+//         components = [MyServiceImpl],
+//         providers = []
+//     }
+// }
+
+struct MyModule<E: Executor> {
+    my_service: Arc<dyn MyService>,
+    _phantom: PhantomData<E>,
+}
+
+impl<E: Executor + Interface> Module for MyModule<E> {
+    type Submodules = ();
+
+    fn build(context: &mut ModuleBuildContext<Self>) -> Self {
+        Self {
+            my_service: Self::build_component(context),
+            _phantom: PhantomData,
+        }
     }
 }
 
-fn build_module<E>(executor: E)
-    where E: Executor,
+impl<E: Executor + Interface> HasComponent<dyn MyService> for MyModule<E> {
+    fn build_component(context: &mut ModuleBuildContext<Self>) -> Arc<dyn MyService> {
+        context.build_component::<MyServiceImpl<E>>()
+    }
+
+    fn resolve(&self) -> Arc<dyn MyService> {
+        Arc::clone(&self.my_service)
+    }
+
+    fn resolve_ref(&self) -> &dyn MyService {
+        Arc::as_ref(&self.my_service)
+    }
+
+    fn resolve_mut(&mut self) -> Option<&mut dyn MyService> {
+        Arc::get_mut(&mut self.my_service)
+    }
+}
+
+fn build_module<E>(executor: E) -> MyModule<E>
+where
+    E: Executor,
 {
-    MyModule::builder()
-        .with_component_parameters::<MyServiceImpl<E>>(MyServiceImplParameters {
-            executor: pool.clone(),
-        })
+    ModuleBuilder::with_submodules(())
+        .with_component_parameters::<MyServiceImpl<E>>(executor)
         .build()
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use shaku::{module, Component, HasComponent, Interface, Module, ModuleBuildContext};
+use shaku::{module, Component, HasComponent, Interface};
 
 pub trait Executor: Interface + Default {}
 
@@ -18,23 +18,14 @@ pub trait MyService: Interface {
     async fn foo(&self) -> u16;
 }
 
-// #[derive(Component)]
-// #[shaku(interface = MyService)]
+#[derive(Component)]
+#[shaku(interface = MyService)]
 pub struct MyServiceImpl<E>
 where
     E: Executor,
 {
     #[allow(dead_code)]
     executor: E,
-}
-
-impl<E: Executor, M: Module> Component<M> for MyServiceImpl<E> {
-    type Interface = dyn MyService;
-    type Parameters = E;
-
-    fn build(_context: &mut ModuleBuildContext<M>, params: E) -> Box<dyn MyService> {
-        Box::new(Self { executor: params })
-    }
 }
 
 #[async_trait]
@@ -59,7 +50,7 @@ where
     E: Executor,
 {
     MyModule::builder()
-        .with_component_parameters::<MyServiceImpl<E>>(executor)
+        .with_component_parameters::<MyServiceImpl<E>>(MyServiceImplParameters { executor })
         .build()
 }
 


### PR DESCRIPTION
This strategy pushes the generic into the module type. This does not require any changes in shaku, as long as you don't use the derive/module macros.

If you want to have a generic interface, such as `dyn MyService<E>` exposed by the module, then this strategy must be used. Otherwise, #2 is another possible strategy.